### PR TITLE
chore: go 1.21.4-bookworm

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.21.1
+FROM --platform=$TARGETPLATFORM golang:1.21.4-bookworm
 ARG TARGETPLATFORM
 COPY ./$TARGETPLATFORM /usr
 RUN git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"

--- a/golang/dockerbuild.sh
+++ b/golang/dockerbuild.sh
@@ -2,7 +2,7 @@
 
 export DOCKER_BUILDKIT=1
 
-TAG="dcard/protoc:3.21.9-golang-1.21.1"
+TAG="dcard/protoc:3.21.9-golang-1.21.4"
 
 [[ -f protoc-21.9-linux-aarch_64.zip ]] || curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-aarch_64.zip
 [[ -f protoc-21.9-linux-x86_64.zip ]] || curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip


### PR DESCRIPTION
## Description

I believe that we need to specify debian to "bookworm" to prevent from glibc errors.

https://dcard.slack.com/archives/GGS0PCJCS/p1701754168399699